### PR TITLE
Use the new maven artifact resolver instead of aether libs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ name := "aether-deploy"
 
 libraryDependencies ++= {
   val mavenVersion = "3.5.0"
-  val aetherVersion = "1.1.0"
+  val mavenResolverVersion = "1.1.1"
   Seq(
     "javax.inject"              % "javax.inject"                  % "1"      % "provided",
     "org.codehaus.plexus"       % "plexus-component-annotations"  % "1.7.1"  % "provided",
@@ -16,13 +16,13 @@ libraryDependencies ++= {
     "org.codehaus.plexus"       % "plexus-interpolation"          % "1.24",
     "org.apache.maven"          % "maven-model"                   % mavenVersion,
     "org.apache.maven"          % "maven-core"                    % mavenVersion,
-    "org.eclipse.aether"        % "aether-impl"                   % aetherVersion,
-    "org.eclipse.aether"        % "aether-connector-basic"        % aetherVersion,
-    "org.eclipse.aether"        % "aether-transport-http"         % aetherVersion exclude("org.apache.httpcomponents", "httpclient"),
-    "org.eclipse.aether"        % "aether-transport-file"         % aetherVersion,
+    "org.apache.maven.resolver" % "maven-resolver-transport-file" % mavenResolverVersion,
+    "org.apache.maven.resolver" % "maven-resolver-connector-basic"% mavenResolverVersion,
+    "org.apache.maven.resolver" % "maven-resolver-transport-http" % mavenResolverVersion,
+    "org.apache.maven.resolver" % "maven-resolver-transport-file" % mavenResolverVersion,
     "org.apache.maven.wagon"    % "wagon-provider-api"            % "2.12",
     "ch.qos.logback"            % "logback-classic"               % "1.2.2",
-    "org.apache.httpcomponents" % "httpclient"                    % "4.5.3" exclude("commons-logging", "commons-logging")
+    "commons-logging"           % "commons-logging"               % "1.2"
   )
 }
 


### PR DESCRIPTION
I was looking for a way to publish artifacts on Nexus with correct `maven-metadata.xml` and I found this plugin to be the only reliable way to do so for both SBT 0.13.x and 1.x. Your plugin is extremely useful because many existing plugins rely on the maven metadata file to be correctly updated e.g. the [sbt-updates](https://github.com/rtimush/sbt-updates).

Besides, the build-in SBT [maven-resolver-plugin](https://www.scala-sbt.org/0.13/docs/Combined+Pages.html#Maven+resolver+plugin) has been broken since SBT 1.x ([sbt/issues/3486](https://github.com/sbt/sbt/issues/3486)). 

However, although the plugin works fine, the eclipse aether project has been discontinued since August 3, 2016 and I decided to upgrade the plugin so that it is using the new [apache maven artifact resolver](https://maven.apache.org/resolver/) which seems to be the continuation of the Aether project. All scripted tests are passing locally. 

See also:
https://projects.eclipse.org/projects/technology.aether/reviews/termination-review