### PR TITLE
Use 'aetherDeploy' scoped 'version' key to allow greater flexibility in version generation.

### DIFF
--- a/aether-deploy/src/main/scala/aether/Plugin.scala
+++ b/aether-deploy/src/main/scala/aether/Plugin.scala
@@ -53,12 +53,13 @@ object AetherPlugin extends AutoPlugin {
       (Keys.`package` in Compile).value
     },
     aetherOldVersionMethod := false,
+    aetherDeploy / version := { if (aetherOldVersionMethod.value) version.value else (ThisBuild / version).value },
     logLevel in aetherDeploy := Level.Debug
   )
 
   def defaultCoordinates = aetherCoordinates := {
     val art        = artifact.value
-    val theVersion = if (aetherOldVersionMethod.value) version.value else (version in ThisBuild).value
+    val theVersion = (aetherDeploy / version).value
 
     val artifactId =
       if (!sbtPlugin.value)


### PR DESCRIPTION
Adds an `aetherDeploy` task scoped `version` settingKey to the default configuration to allow end user to plug into version used for deployment directly. (`version in aetherDeploy` /  `aetherDeploy / version`)

Required in our case using VCS derived versions and needing to deploy pre-releases with -SNAPSHOT suffix while retaining version information.
