### PR TITLE
Write valid maven-metadata.xml for sbt plugins

### DIFF
--- a/aether-deploy/src/main/java/aether/maven/MavenMetadata.java
+++ b/aether-deploy/src/main/java/aether/maven/MavenMetadata.java
@@ -1,0 +1,137 @@
+package aether.maven;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
+import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Writer;
+import org.codehaus.plexus.util.ReaderFactory;
+import org.codehaus.plexus.util.WriterFactory;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.eclipse.aether.RepositoryException;
+import org.eclipse.aether.metadata.AbstractMetadata;
+import org.eclipse.aether.metadata.MergeableMetadata;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @author Benjamin Bentmann
+ */
+abstract class MavenMetadata
+    extends AbstractMetadata
+    implements MergeableMetadata
+{
+
+    static final String MAVEN_METADATA_XML = "maven-metadata.xml";
+
+    private final File file;
+
+    protected Metadata metadata;
+
+    private boolean merged;
+
+    protected MavenMetadata( Metadata metadata, File file )
+    {
+        this.metadata = metadata;
+        this.file = file;
+    }
+
+    public String getType()
+    {
+        return MAVEN_METADATA_XML;
+    }
+
+    public File getFile()
+    {
+        return file;
+    }
+
+    public void merge( File existing, File result )
+        throws RepositoryException
+    {
+        Metadata recessive = read( existing );
+
+        merge( recessive );
+
+        write( result, metadata );
+
+        merged = true;
+    }
+
+    public boolean isMerged()
+    {
+        return merged;
+    }
+
+    protected abstract void merge( Metadata recessive );
+
+    static Metadata read( File metadataFile )
+        throws RepositoryException
+    {
+        if ( metadataFile.length() <= 0 )
+        {
+            return new Metadata();
+        }
+
+        try ( Reader reader = ReaderFactory.newXmlReader( metadataFile ) )
+        {
+            return new MetadataXpp3Reader().read( reader, false );
+        }
+        catch ( IOException e )
+        {
+            throw new RepositoryException( "Could not read metadata " + metadataFile + ": " + e.getMessage(), e );
+        }
+        catch ( XmlPullParserException e )
+        {
+            throw new RepositoryException( "Could not parse metadata " + metadataFile + ": " + e.getMessage(), e );
+        }
+    }
+
+    private void write( File metadataFile, Metadata metadata )
+        throws RepositoryException
+    {
+        metadataFile.getParentFile().mkdirs();
+        try ( Writer writer = WriterFactory.newXmlWriter( metadataFile ) )
+        {
+            new MetadataXpp3Writer().write( writer, metadata );
+        }
+        catch ( IOException e )
+        {
+            throw new RepositoryException( "Could not write metadata " + metadataFile + ": " + e.getMessage(), e );
+        }
+    }
+
+    public Map<String, String> getProperties()
+    {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public org.eclipse.aether.metadata.Metadata setProperties( Map<String, String> properties )
+    {
+        return this;
+    }
+
+}

--- a/aether-deploy/src/main/java/aether/maven/VersionsMetadata.java
+++ b/aether-deploy/src/main/java/aether/maven/VersionsMetadata.java
@@ -1,0 +1,141 @@
+package aether.maven;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+
+import aether.MavenCoordinates;
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.apache.maven.artifact.repository.metadata.Versioning;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.ArtifactProperties;
+
+/**
+ * @author Benjamin Bentmann
+ */
+final class VersionsMetadata
+    extends MavenMetadata
+{
+
+    private final Artifact artifact;
+
+    VersionsMetadata( Artifact artifact )
+    {
+        super( createRepositoryMetadata( artifact ), null );
+        this.artifact = artifact;
+    }
+
+    VersionsMetadata( Artifact artifact, File file )
+    {
+        super( createRepositoryMetadata( artifact ), file );
+        this.artifact = artifact;
+    }
+
+    private static Metadata createRepositoryMetadata( Artifact artifact )
+    {
+        Metadata metadata = new Metadata();
+        metadata.setGroupId( artifact.getGroupId() );
+
+        boolean sbtPlugin = Boolean.parseBoolean(artifact.getProperty( MavenCoordinates.SbtPlugin(), "false" )) ;
+        if ( sbtPlugin ) {
+            String scalaVersion = artifact.getProperty( MavenCoordinates.ScalaVersion(), "" ) ;
+            String sbtVersion = artifact.getProperty( MavenCoordinates.SbtVersion(), "" ) ;
+            metadata.setArtifactId( artifact.getArtifactId() + "_" + scalaVersion + "_" + sbtVersion );
+        } else {
+            metadata.setArtifactId( artifact.getArtifactId() );
+        }
+        Versioning versioning = new Versioning();
+        versioning.addVersion( artifact.getBaseVersion() );
+        if ( !artifact.isSnapshot() )
+        {
+            versioning.setRelease( artifact.getBaseVersion() );
+        }
+        if ( "maven-plugin".equals( artifact.getProperty( ArtifactProperties.TYPE, "" ) ) )
+        {
+            versioning.setLatest( artifact.getBaseVersion() );
+        }
+
+        metadata.setVersioning( versioning );
+
+        return metadata;
+    }
+
+    @Override
+    protected void merge( Metadata recessive )
+    {
+        Versioning versioning = metadata.getVersioning();
+        versioning.updateTimestamp();
+
+        if ( recessive.getVersioning() != null )
+        {
+            if ( versioning.getLatest() == null )
+            {
+                versioning.setLatest( recessive.getVersioning().getLatest() );
+            }
+            if ( versioning.getRelease() == null )
+            {
+                versioning.setRelease( recessive.getVersioning().getRelease() );
+            }
+
+            Collection<String> versions = new LinkedHashSet<>( recessive.getVersioning().getVersions() );
+            versions.addAll( versioning.getVersions() );
+            versioning.setVersions( new ArrayList<>( versions ) );
+        }
+    }
+
+    public Object getKey()
+    {
+        return getGroupId() + ':' + getArtifactId();
+    }
+
+    public static Object getKey( Artifact artifact )
+    {
+        return artifact.getGroupId() + ':' + artifact.getArtifactId();
+    }
+
+    public MavenMetadata setFile( File file )
+    {
+        return new VersionsMetadata( artifact, file );
+    }
+
+    public String getGroupId()
+    {
+        return artifact.getGroupId();
+    }
+
+    public String getArtifactId()
+    {
+        return artifact.getArtifactId();
+    }
+
+    public String getVersion()
+    {
+        return "";
+    }
+
+    public Nature getNature()
+    {
+        return artifact.isSnapshot() ? Nature.RELEASE_OR_SNAPSHOT : Nature.RELEASE;
+    }
+
+}

--- a/aether-deploy/src/main/java/aether/maven/VersionsMetadataGenerator.java
+++ b/aether-deploy/src/main/java/aether/maven/VersionsMetadataGenerator.java
@@ -1,0 +1,108 @@
+package aether.maven;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.deployment.DeployRequest;
+import org.eclipse.aether.impl.MetadataGenerator;
+import org.eclipse.aether.installation.InstallRequest;
+import org.eclipse.aether.metadata.Metadata;
+
+/**
+ * @author Benjamin Bentmann
+ */
+class VersionsMetadataGenerator
+    implements MetadataGenerator
+{
+
+    private Map<Object, VersionsMetadata> versions;
+
+    private Map<Object, VersionsMetadata> processedVersions;
+
+    VersionsMetadataGenerator( RepositorySystemSession session, InstallRequest request )
+    {
+        this( session, request.getMetadata() );
+    }
+
+    VersionsMetadataGenerator( RepositorySystemSession session, DeployRequest request )
+    {
+        this( session, request.getMetadata() );
+    }
+
+    private VersionsMetadataGenerator( RepositorySystemSession session, Collection<? extends Metadata> metadatas )
+    {
+        versions = new LinkedHashMap<>();
+        processedVersions = new LinkedHashMap<>();
+
+        /*
+         * NOTE: This should be considered a quirk to support interop with Maven's legacy ArtifactDeployer which
+         * processes one artifact at a time and hence cannot associate the artifacts from the same project to use the
+         * same version index. Allowing the caller to pass in metadata from a previous deployment allows to re-establish
+         * the association between the artifacts of the same project.
+         */
+        for ( Iterator<? extends Metadata> it = metadatas.iterator(); it.hasNext(); )
+        {
+            Metadata metadata = it.next();
+            if ( metadata instanceof VersionsMetadata )
+            {
+                it.remove();
+                VersionsMetadata versionsMetadata = (VersionsMetadata) metadata;
+                processedVersions.put( versionsMetadata.getKey(), versionsMetadata );
+            }
+        }
+    }
+
+    public Collection<? extends Metadata> prepare( Collection<? extends Artifact> artifacts )
+    {
+        return Collections.emptyList();
+    }
+
+    public Artifact transformArtifact( Artifact artifact )
+    {
+        return artifact;
+    }
+
+    public Collection<? extends Metadata> finish( Collection<? extends Artifact> artifacts )
+    {
+        for ( Artifact artifact : artifacts )
+        {
+            Object key = VersionsMetadata.getKey( artifact );
+            if ( processedVersions.get( key ) == null )
+            {
+                VersionsMetadata versionsMetadata = versions.get( key );
+                if ( versionsMetadata == null )
+                {
+                    versionsMetadata = new VersionsMetadata( artifact );
+                    versions.put( key, versionsMetadata );
+                }
+            }
+        }
+
+        return versions.values();
+    }
+
+}

--- a/aether-deploy/src/main/java/aether/maven/VersionsMetadataGeneratorFactory.java
+++ b/aether-deploy/src/main/java/aether/maven/VersionsMetadataGeneratorFactory.java
@@ -1,0 +1,55 @@
+package aether.maven;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.deployment.DeployRequest;
+import org.eclipse.aether.impl.MetadataGenerator;
+import org.eclipse.aether.impl.MetadataGeneratorFactory;
+import org.eclipse.aether.installation.InstallRequest;
+
+/**
+ * @author Benjamin Bentmann
+ */
+@Named( "versions" )
+@Singleton
+public class VersionsMetadataGeneratorFactory
+    implements MetadataGeneratorFactory
+{
+
+    public MetadataGenerator newInstance( RepositorySystemSession session, InstallRequest request )
+    {
+        return new VersionsMetadataGenerator( session, request );
+    }
+
+    public MetadataGenerator newInstance( RepositorySystemSession session, DeployRequest request )
+    {
+        return new VersionsMetadataGenerator( session, request );
+    }
+
+    public float getPriority()
+    {
+        return 5;
+    }
+
+}

--- a/aether-deploy/src/main/scala/aether/AetherArtifact.scala
+++ b/aether-deploy/src/main/scala/aether/AetherArtifact.scala
@@ -14,6 +14,7 @@ case class MavenCoordinates(
 ) {
   def coordinates = "%s:%s:%s%s:%s".format(groupId, artifactId, extension, classifier.map(_ + ":").getOrElse(""), version)
 
+  def sbtPlugin()                 = withProp(MavenCoordinates.SbtPlugin, "true")
   def withScalaVersion(v: String) = withProp(MavenCoordinates.ScalaVersion, v)
   def withSbtVersion(v: String)   = withProp(MavenCoordinates.SbtVersion, v)
   def withExtension(file: File) = {
@@ -28,6 +29,7 @@ case class MavenCoordinates(
 }
 
 object MavenCoordinates {
+  val SbtPlugin = "sbt-plugin"
   val ScalaVersion = "scala-version"
   val SbtVersion   = "sbt-version"
 
@@ -47,7 +49,6 @@ case class AetherSubArtifact(file: File, classifier: Option[String] = None, exte
 }
 
 case class AetherArtifact(file: File, coordinates: MavenCoordinates, subartifacts: Seq[AetherSubArtifact] = Nil) {
-  def isSbtPlugin = coordinates.props.contains(MavenCoordinates.SbtVersion)
 
   def attach(file: File, classifier: String, extension: String = "jar") = {
     copy(subartifacts = subartifacts :+ AetherSubArtifact(file, Some(classifier), extension))

--- a/aether-deploy/src/main/scala/aether/Plugin.scala
+++ b/aether-deploy/src/main/scala/aether/Plugin.scala
@@ -70,7 +70,7 @@ object AetherPlugin extends AutoPlugin {
       else art.name
     val coords = MavenCoordinates(organization.value, artifactId, theVersion, None, art.extension)
     if (sbtPlugin.value)
-      coords.withSbtVersion((sbtBinaryVersion in pluginCrossBuild).value).withScalaVersion(scalaBinaryVersion.value)
+      coords.sbtPlugin().withSbtVersion((sbtBinaryVersion in pluginCrossBuild).value).withScalaVersion(scalaBinaryVersion.value)
     else coords
   }
 

--- a/aether-deploy/src/main/scala/aether/internal/Booter.scala
+++ b/aether-deploy/src/main/scala/aether/internal/Booter.scala
@@ -3,7 +3,8 @@ package internal
 
 import java.io.File
 
-import org.apache.maven.repository.internal._
+import aether.maven.VersionsMetadataGeneratorFactory
+import org.apache.maven.repository.internal.{DefaultArtifactDescriptorReader, DefaultVersionRangeResolver, DefaultVersionResolver, SnapshotMetadataGeneratorFactory}
 import org.eclipse.aether.deployment.DeployRequest
 import org.eclipse.aether.{ConfigurationProperties, DefaultRepositorySystemSession, RepositorySystem, RepositorySystemSession}
 import org.eclipse.aether.impl._


### PR DESCRIPTION
Fixes #64 

In order to write a valid `maven-metadata.xml` file the behaviour of `org.apache.maven.repository.internal.VersionsMetadata` needs to be changed, so that it writes the `artifactId` element using the correct format `$name_$scalaVersion_$sbtVersion`. 

Unfortunately, the class `VersionsMetadata` class is final and internal so it's not possible to simply extend its behaviour, so I'm forced to create a whole new implementation and replace all the generators, all the way from `Booter.scala`. For this reason, the following classes were copied directly from the Maven sources but not modified:
- `MavenMetadata`
- `VersionsMetadataGenerator`
- `VersionsMetadataGeneratorFactory.java`

I decided to simply copy these classes as is, so that if Maven changes them it's easy to compare them and apply patches. I've also considered rewriting them in Scala, but it has the disadvantage of diverging further from Maven and possibly creating new bugs.

