### PR TITLE
Switch publishing to CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - directory: /
+    open-pull-requests-limit: 10
+    package-ecosystem: github-actions
+    rebase-strategy: auto
+    schedule:
+      interval: daily

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Test
 on:
   push:
     branches: [ '*' ]
+    tags: [ 'v*' ]
   pull_request:
     branches: [ master ]
   workflow_dispatch:
@@ -73,3 +74,57 @@ jobs:
         uses: coursier/cache-action@v8
       - name: Verify Source Formatting
         run: sbt "scalafmtCheckAll; scalafmtSbtCheck"
+
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    name: Publish Release
+    needs: [ test, check ]
+    if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK ${{ env.JDK_RELEASE }}
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JDK_RELEASE }}
+          distribution: temurin
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+      - name: Set up Coursier cache
+        uses: coursier/cache-action@v8
+      - name: Import Signing Key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.SIGNING_KEY }}
+          trust_level: 5
+      - name: Publish Release
+        run: sbt "publishSigned; sonaUpload; sonaRelease"
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: Create GitHub Release
+    needs: [ publish ]
+    if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prerelease_flag=""
+          if [[ "${{ github.ref_name }}" == *-* ]]; then
+            prerelease_flag="--prerelease"
+          fi
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            --verify-tag \
+            $prerelease_flag

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,5 +1,3 @@
-credentials += Credentials(Path.userHome / ".sbt" / "arktekk-credentials")
-
 pomIncludeRepository := { x =>
   false
 }


### PR DESCRIPTION
Quick take at solving issues like #71 by switching publishing to CI.

With this setup, every tag starting with `v` will be deployed to Sonatype automatically.

For it to work, a number of Github Secrets will need to be added as specified below.

For the GPG key, I would personally create another key specifically used for CI publishing, to avoid exposing your existing key to any possible vulnerabilities.

| Secrets needed:     |                                                                                            |
|---------------------|--------------------------------------------------------------------------------------------|
| `SIGNING_KEY`       | ASCII-armored secret PGP key, passphraseless. Imported by `crazy-max/ghaction-import-gpg`. |
| `SONATYPE_USERNAME` | Sonatype Central username (or user-token username). Auto-resolved by sbt 2.x.              |
| `SONATYPE_PASSWORD` | Sonatype Central password (or user-token secret). Auto-resolved by sbt 2.x.                |
