### PR TITLE
Cross build against sbt 1x and sbt 2x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,17 @@ jobs:
         uses: sbt/setup-sbt@v1
       - name: Set up Coursier cache
         uses: coursier/cache-action@v8
+      - name: Generate ephemeral GPG key for signed scripted tests
+        run: |
+          gpg --batch --gen-key <<EOF
+          %no-protection
+          Key-Type: RSA
+          Key-Length: 2048
+          Name-Real: aether-deploy CI
+          Name-Email: ci@aether-deploy.invalid
+          Expire-Date: 0
+          %commit
+          EOF
       - name: "[sbt ${{ matrix.sbt }}.x] Scripted Tests"
         run: sbt aetherDeployRoot${{ matrix.version-suffix }}/scripted
 
@@ -59,7 +70,4 @@ jobs:
       - name: Set up Coursier cache
         uses: coursier/cache-action@v8
       - name: Verify Source Formatting
-        id: scalafmt
         run: sbt "scalafmtCheckAll; scalafmtSbtCheck"
-
-    # Handle gpg signed stuff

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,22 +5,61 @@ on:
     branches: [ '*' ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  JDK_RELEASE: 17
+  SBT_OPTS: >-
+    -Xmx10G
+    -Xss2M
+    -XX:ReservedCodeCacheSize=512M
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: "[sbt ${{ matrix.sbt }}.x] Tests"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sbt: '1'
+            version-suffix: '2_12'
+          - sbt: '2'
+            version-suffix: ''
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - name: Set up JDK ${{ env.JDK_RELEASE }}
+        uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: ${{ env.JDK_RELEASE }}
           distribution: temurin
-          cache: sbt
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
-      - name: Scalafmt Check
-        run: sbt scalafmtCheckAll
-      - name: "aetherDeploy Scripted"
-        run: sbt aetherDeploy/scripted
+      - name: Set up Coursier cache
+        uses: coursier/cache-action@v8
+      - name: "[sbt ${{ matrix.sbt }}.x] Scripted Tests"
+        run: sbt aetherDeployRoot${{ matrix.version-suffix }}/scripted
+
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    name: Static Code Checks
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK ${{ env.JDK_RELEASE }}
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JDK_RELEASE }}
+          distribution: temurin
+      - name: Set up Coursier cache
+        uses: coursier/cache-action@v8
+      - name: Verify Source Formatting
+        id: scalafmt
+        run: sbt "scalafmtCheckAll; scalafmtSbtCheck"
+
     # Handle gpg signed stuff

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,8 @@ jobs:
         with:
           java-version: ${{ env.JDK_RELEASE }}
           distribution: temurin
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
       - name: Set up Coursier cache
         uses: coursier/cache-action@v8
       - name: Verify Source Formatting

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ target
 .metals
 .bloop
 .bsp
+.vscode
+**/sbt-test/**/disabled

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
-version = 2.7.5
-
+version = 3.11.0
+runner.dialect = scala212source3
 align = most    # For pretty alignment.
 maxColumn = 130
 rewrite.rules = [SortImports]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,3 +3,13 @@ runner.dialect = scala212source3
 align.preset = most    # For pretty alignment.
 maxColumn = 130
 rewrite.rules = [SortImports]
+
+# build.sbt and meta-build sources run on sbt 2.x (Scala 3)
+fileOverride {
+  "glob:**/*.sbt" {
+    runner.dialect = scala3
+  }
+  "glob:**/project/**/*.scala" {
+    runner.dialect = scala3
+  }
+}

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version = 3.11.0
 runner.dialect = scala212source3
-align = most    # For pretty alignment.
+align.preset = most    # For pretty alignment.
 maxColumn = 130
 rewrite.rules = [SortImports]

--- a/README.md
+++ b/README.md
@@ -20,8 +20,23 @@ addSbtPlugin("no.arktekk.sbt" % "aether-deploy-signed" % "0.30.0") // For sbt-pg
 ## 0.31.0
 
 - Support sbt 2.x.
-- Calling `AetherArtifact.attach` directly requires an implicit `xsbti.FileConverter`
-  in scope. Supply it from the task body:
+
+- `version` is now sourced per-project (previously always taken from `ThisBuild / version`). Required to align with
+  sbt 2.x's bare-settings convention. See also
+  [Migrating `ThisBuild`](https://www.scala-sbt.org/2.x/docs/en/changes/migrating-from-sbt-1.x.html#migrating-thisbuild)
+  in the sbt 2 migration guide.
+
+  Most builds are unaffected: `version` falls back to `ThisBuild / version` via sbt's standard scope delegation. The
+  change matters only if your build sets both `ThisBuild / version` _and_ a different per-project `version` - publish
+  coordinates now match the project-scope value. To restore the old behaviour, set in the affected project:
+
+  ```scala
+  version := (ThisBuild / version).value
+  ```
+
+- Calling `AetherArtifact.attach` directly requires an implicit `xsbti.FileConverter` in scope. Supply it from the task
+  body (as below), or use the new [`attachSubArtifact` helper](#attaching-additional-sub-artefacts), which does not
+  require either:
 
   ```scala
   aetherArtifact := {
@@ -30,24 +45,13 @@ addSbtPlugin("no.arktekk.sbt" % "aether-deploy-signed" % "0.30.0") // For sbt-pg
   }
   ```
 
-  Or use the new [`attachSubArtifact`](#attaching-additional-sub-artefacts) helper, which does not require either.
-
-- If you call `AetherPlugin.deployIt` or `AetherPlugin.installIt` directly from
-  a custom task, the trailing `TaskStreams` parameter is no longer `implicit` -
-  pass `streams.value` as a regular argument:
+- If you call `AetherPlugin.deployIt` or `AetherPlugin.installIt` directly from a custom task, the trailing
+  `TaskStreams` parameter is no longer `implicit` - pass `streams.value` as a regular argument:
 
   ```scala
   AetherPlugin.deployIt(repo, localRepo, artifact, creds, headers)(streams.value)
   AetherPlugin.installIt(artifact, localRepo)(streams.value)
   ```
-
-- `version` was previously always sourced from `ThisBuild` scope. Project scoped
-  version would be silently ignored. Builds that set `ThisBuild / version := "..."`
-  are unaffected. Builds that set `version` independently per module will now have
-  publish coordinates matching generated POMs.
-
-  If you actually want aether to ignore an explicit project-scope `version` override
-  use: `version := (ThisBuild / version).value` in that project's settings.
 
 ## 0.30.0
 Only support new plugin layouts

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ addSbtPlugin("no.arktekk.sbt" % "aether-deploy-signed" % "0.30.0") // For sbt-pg
   Or use the new [`attachSubArtifact`](#attaching-additional-sub-artefacts) helper,
   which does not require either.
 
+- If you call `AetherPlugin.deployIt` or `AetherPlugin.installIt` directly from
+  a custom task, the trailing `TaskStreams` parameter is no longer `implicit` -
+  pass `streams.value` as a regular argument:
+
+  ```scala
+  AetherPlugin.deployIt(repo, localRepo, artifact, creds, headers)(streams.value)
+  AetherPlugin.installIt(artifact, localRepo)(streams.value)
+  ```
+
 ## 0.30.0
 Only support new plugin layouts
 Remove aetherOldVersionMethod key

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # SBT aether deploy plugin
-Deploys sbt-artifacts using Maven Artifact Provider. 
+Deploys sbt-artifacts using Maven Artifact Provider.
 
 The same behaviour as Maven should be expected.
+
+Cross-built for **sbt 1.x** and **sbt 2.x**.
 
 ## project/plugins.sbt
 
@@ -14,6 +16,22 @@ addSbtPlugin("no.arktekk.sbt" % "aether-deploy-signed" % "0.30.0") // For sbt-pg
 ```
 
 # Breaking Changes
+
+## 0.31.0
+
+- Support sbt 2.x.
+- Calling `AetherArtifact.attach` directly requires an implicit `xsbti.FileConverter`
+  in scope. Supply it from the task body:
+
+  ```scala
+  aetherArtifact := {
+    implicit val conv: xsbti.FileConverter = fileConverter.value
+    aetherArtifact.value.attach(myFileTask.value, "classifier", "ext")
+  }
+  ```
+
+  Or use the new [`attachSubArtifact`](#attaching-additional-sub-artefacts) helper,
+  which does not require either.
 
 ## 0.30.0
 Only support new plugin layouts
@@ -110,6 +128,15 @@ overridePublishSignedLocalSettings
 
 ```scala
 overridePublishSignedBothSettings
+```
+
+## Attaching additional sub-artefacts
+
+Attach a packaged-file task (e.g. a zip produced by `Universal / packageBin`) as a
+sub-artefact alongside the main jar:
+
+```scala
+attachSubArtifact(Universal / packageBin, "dist", "zip")
 ```
 
 ## Add credentials

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ addSbtPlugin("no.arktekk.sbt" % "aether-deploy-signed" % "0.30.0") // For sbt-pg
   }
   ```
 
-  Or use the new [`attachSubArtifact`](#attaching-additional-sub-artefacts) helper,
-  which does not require either.
+  Or use the new [`attachSubArtifact`](#attaching-additional-sub-artefacts) helper, which does not require either.
 
 - If you call `AetherPlugin.deployIt` or `AetherPlugin.installIt` directly from
   a custom task, the trailing `TaskStreams` parameter is no longer `implicit` -
@@ -41,6 +40,14 @@ addSbtPlugin("no.arktekk.sbt" % "aether-deploy-signed" % "0.30.0") // For sbt-pg
   AetherPlugin.deployIt(repo, localRepo, artifact, creds, headers)(streams.value)
   AetherPlugin.installIt(artifact, localRepo)(streams.value)
   ```
+
+- `version` was previously always sourced from `ThisBuild` scope. Project scoped
+  version would be silently ignored. Builds that set `ThisBuild / version := "..."`
+  are unaffected. Builds that set `version` independently per module will now have
+  publish coordinates matching generated POMs.
+
+  If you actually want aether to ignore an explicit project-scope `version` override
+  use: `version := (ThisBuild / version).value` in that project's settings.
 
 ## 0.30.0
 Only support new plugin layouts

--- a/aether-deploy-signed/src/main/scala/aether/SignedAetherPlugin.scala
+++ b/aether-deploy-signed/src/main/scala/aether/SignedAetherPlugin.scala
@@ -22,13 +22,13 @@ object SignedAetherPlugin extends AutoPlugin {
   )
 
   object autoImport {
-    def overridePublishSignedSettings: Seq[Setting[_]]      = Seq(PgpKeys.publishSigned := aetherDeploy.value)
-    def overridePublishSignedLocalSettings: Seq[Setting[_]] =
+    def overridePublishSignedSettings: Seq[Setting[?]]      = Seq(PgpKeys.publishSigned := aetherDeploy.value)
+    def overridePublishSignedLocalSettings: Seq[Setting[?]] =
       Seq(PgpKeys.publishLocalSigned := {
         aetherInstall.value
         PgpKeys.publishLocalSigned.value
       })
-    def overridePublishSignedBothSettings: Seq[Setting[_]]  = overridePublishSignedSettings ++ overridePublishSignedLocalSettings
+    def overridePublishSignedBothSettings: Seq[Setting[?]]  = overridePublishSignedSettings ++ overridePublishSignedLocalSettings
   }
 
 }

--- a/aether-deploy-signed/src/main/scala/aether/SignedAetherPlugin.scala
+++ b/aether-deploy-signed/src/main/scala/aether/SignedAetherPlugin.scala
@@ -3,12 +3,16 @@ package aether
 import aether.AetherKeys._
 import com.jsuereth.sbtpgp.{PgpKeys, SbtPgp}
 import sbt._
+import sbt.Keys.fileConverter
+import sbtcompat.PluginCompat._
+import xsbti.FileConverter
 
 object SignedAetherPlugin extends AutoPlugin {
   override def trigger         = allRequirements
   override def requires        = AetherPlugin && SbtPgp
   override def projectSettings = Seq(
-    aetherArtifact := {
+    aetherArtifact := Def.uncached {
+      implicit val conv: FileConverter = fileConverter.value
       AetherPlugin.createArtifact(
         (Compile / PgpKeys.signedArtifacts).value,
         aetherCoordinates.value,

--- a/aether-deploy-signed/src/sbt-test/deploy/deploy-file-with-gpg/build.sbt
+++ b/aether-deploy-signed/src/sbt-test/deploy/deploy-file-with-gpg/build.sbt
@@ -1,11 +1,13 @@
-version in ThisBuild  := "0.1"
+ThisBuild / version := "0.1"
 
 name := "deploy-file"
 
 organization := "deploy-file"
 
-scalaVersion := "2.11.6"
+scalaVersion := "3.8.3"
 
-publishTo  := Some("foo" at (file(".") / "target" / "repo").toURI.toURL.toString)
+publishTo := Some("foo" at (file(".") / "target" / "repo").toURI.toURL.toString)
 
 overridePublishSignedSettings
+
+crossPaths := false

--- a/aether-deploy-signed/src/sbt-test/deploy/deploy-file-with-gpg/test
+++ b/aether-deploy-signed/src/sbt-test/deploy/deploy-file-with-gpg/test
@@ -1,13 +1,13 @@
-# Deploy to file url
+# Signed deploy to file url.
 > publishSigned
 $ exists target/repo/deploy-file
-$ exists target/repo/deploy-file/deploy-file_2.11/maven-metadata.xml
-$ exists target/repo/deploy-file/deploy-file_2.11/0.1/
-$ exists target/repo/deploy-file/deploy-file_2.11/0.1/deploy-file_2.11-0.1.jar
-$ exists target/repo/deploy-file/deploy-file_2.11/0.1/deploy-file_2.11-0.1.jar.asc
-$ exists target/repo/deploy-file/deploy-file_2.11/0.1/deploy-file_2.11-0.1.pom
-$ exists target/repo/deploy-file/deploy-file_2.11/0.1/deploy-file_2.11-0.1.pom.asc
-$ exists target/repo/deploy-file/deploy-file_2.11/0.1/deploy-file_2.11-0.1-sources.jar
-$ exists target/repo/deploy-file/deploy-file_2.11/0.1/deploy-file_2.11-0.1-sources.jar.asc
-$ exists target/repo/deploy-file/deploy-file_2.11/0.1/deploy-file_2.11-0.1-javadoc.jar
-$ exists target/repo/deploy-file/deploy-file_2.11/0.1/deploy-file_2.11-0.1-javadoc.jar.asc
+$ exists target/repo/deploy-file/deploy-file/maven-metadata.xml
+$ exists target/repo/deploy-file/deploy-file/0.1/
+$ exists target/repo/deploy-file/deploy-file/0.1/deploy-file-0.1.jar
+$ exists target/repo/deploy-file/deploy-file/0.1/deploy-file-0.1.jar.asc
+$ exists target/repo/deploy-file/deploy-file/0.1/deploy-file-0.1.pom
+$ exists target/repo/deploy-file/deploy-file/0.1/deploy-file-0.1.pom.asc
+$ exists target/repo/deploy-file/deploy-file/0.1/deploy-file-0.1-sources.jar
+$ exists target/repo/deploy-file/deploy-file/0.1/deploy-file-0.1-sources.jar.asc
+$ exists target/repo/deploy-file/deploy-file/0.1/deploy-file-0.1-javadoc.jar
+$ exists target/repo/deploy-file/deploy-file/0.1/deploy-file-0.1-javadoc.jar.asc

--- a/aether-deploy/src/main/scala/aether/AetherArtifact.scala
+++ b/aether-deploy/src/main/scala/aether/AetherArtifact.scala
@@ -1,8 +1,12 @@
 package aether
 
 import java.io.File
+
 import org.eclipse.aether.util.artifact.SubArtifact
 import org.eclipse.aether.artifact.DefaultArtifact
+
+import sbtcompat.PluginCompat
+import xsbti.FileConverter
 
 case class MavenCoordinates(
     groupId: String,
@@ -50,9 +54,9 @@ case class AetherSubArtifact(file: File, classifier: Option[String] = None, exte
 
 case class AetherArtifact(file: File, coordinates: MavenCoordinates, subartifacts: Seq[AetherSubArtifact] = Nil) {
 
-  def attach(file: File, classifier: String, extension: String = "jar") = {
-    copy(subartifacts = subartifacts :+ AetherSubArtifact(file, Some(classifier), extension))
-  }
+  def attach(ref: PluginCompat.FileRef, classifier: String, extension: String = "jar")
+            (implicit conv: FileConverter): AetherArtifact =
+    copy(subartifacts = subartifacts :+ AetherSubArtifact(PluginCompat.toFile(ref), Some(classifier), extension))
 
   import collection.JavaConverters._
   def toArtifact = new DefaultArtifact(

--- a/aether-deploy/src/main/scala/aether/AetherArtifact.scala
+++ b/aether-deploy/src/main/scala/aether/AetherArtifact.scala
@@ -59,7 +59,7 @@ case class AetherArtifact(file: File, coordinates: MavenCoordinates, subartifact
   ): AetherArtifact =
     copy(subartifacts = subartifacts :+ AetherSubArtifact(PluginCompat.toFile(ref), Some(classifier), extension))
 
-  import collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
   def toArtifact = new DefaultArtifact(
     coordinates.groupId,
     coordinates.artifactId,

--- a/aether-deploy/src/main/scala/aether/AetherArtifact.scala
+++ b/aether-deploy/src/main/scala/aether/AetherArtifact.scala
@@ -21,7 +21,7 @@ case class MavenCoordinates(
   def sbtPlugin()                 = withProp(MavenCoordinates.SbtPlugin, "true")
   def withScalaVersion(v: String) = withProp(MavenCoordinates.ScalaVersion, v)
   def withSbtVersion(v: String)   = withProp(MavenCoordinates.SbtVersion, v)
-  def withExtension(file: File) = {
+  def withExtension(file: File)   = {
     val ext = {
       val i = file.getName.lastIndexOf(".")
       file.getName.substring(i + 1)

--- a/aether-deploy/src/main/scala/aether/AetherArtifact.scala
+++ b/aether-deploy/src/main/scala/aether/AetherArtifact.scala
@@ -54,8 +54,9 @@ case class AetherSubArtifact(file: File, classifier: Option[String] = None, exte
 
 case class AetherArtifact(file: File, coordinates: MavenCoordinates, subartifacts: Seq[AetherSubArtifact] = Nil) {
 
-  def attach(ref: PluginCompat.FileRef, classifier: String, extension: String = "jar")
-            (implicit conv: FileConverter): AetherArtifact =
+  def attach(ref: PluginCompat.FileRef, classifier: String, extension: String = "jar")(implicit
+      conv: FileConverter
+  ): AetherArtifact =
     copy(subartifacts = subartifacts :+ AetherSubArtifact(PluginCompat.toFile(ref), Some(classifier), extension))
 
   import collection.JavaConverters._

--- a/aether-deploy/src/main/scala/aether/Plugin.scala
+++ b/aether-deploy/src/main/scala/aether/Plugin.scala
@@ -11,6 +11,10 @@ import java.net.URI
 import org.eclipse.aether.repository.RemoteRepository.Builder
 import org.eclipse.aether.util.repository.AuthenticationBuilder
 
+import sbtcompat.PluginCompat
+import sbtcompat.PluginCompat._
+import xsbti.FileConverter
+
 import scala.util.{Failure, Success, Try}
 
 object AetherKeys {
@@ -21,6 +25,19 @@ object AetherKeys {
   val aetherPackageMain       = taskKey[File]("package main Artifact")
   val aetherLocalRepo         = settingKey[File]("Local maven repository.")
   val aetherCustomHttpHeaders = settingKey[Map[String, String]]("Add these headers to the http request")
+
+  /** Attach an additional sub-artefact (sourced from a task that produces a packaged file)
+    * to the main `aetherArtifact`.
+    */
+  def attachSubArtifact(
+      packageTask: sbt.TaskKey[sbtcompat.PluginCompat.FileRef],
+      classifier: String,
+      extension: String = "jar"
+  ): Def.Setting[sbt.Task[AetherArtifact]] =
+    aetherArtifact := Def.uncached {
+      implicit val conv: xsbti.FileConverter = sbt.Keys.fileConverter.value
+      aetherArtifact.value.attach(packageTask.value, classifier, extension)
+    }
 }
 
 import AetherKeys._
@@ -29,7 +46,8 @@ object AetherPlugin extends AutoPlugin {
   override def trigger         = allRequirements
   override def requires        = sbt.plugins.IvyPlugin
   override def projectSettings = aetherBaseSettings ++ Seq(
-    aetherArtifact := {
+    aetherArtifact := Def.uncached {
+      implicit val conv: FileConverter = fileConverter.value
       createArtifact(
         (Compile / packagedArtifacts).value,
         aetherCoordinates.value,
@@ -53,8 +71,9 @@ object AetherPlugin extends AutoPlugin {
     defaultCoordinates,
     deployTask,
     installTask,
-    aetherPackageMain := {
-      (Compile / Keys.`package`).value
+    aetherPackageMain := Def.uncached {
+      implicit val conv: FileConverter = fileConverter.value
+      PluginCompat.toFile((Compile / Keys.`package`).value)
     },
     sbtPluginPublishLegacyMavenStyle := false,
     aetherDeploy / version := (ThisBuild / version).value,
@@ -65,17 +84,29 @@ object AetherPlugin extends AutoPlugin {
   def defaultCoordinates = aetherCoordinates := {
     val art        = artifact.value
     val theVersion = (aetherDeploy / version).value
-
-    val defaultArtifactId =
-      CrossVersion(crossVersion.value, scalaVersion.value, scalaBinaryVersion.value).map(_(art.name)) getOrElse art.name
+    val sbtBin     = (pluginCrossBuild / sbtBinaryVersion).value
+    val scalaBin   = scalaBinaryVersion.value
 
     val artifactId =
-      if (sbtPlugin.value) "%s_%s".format(defaultArtifactId, (pluginCrossBuild / sbtBinaryVersion).value)
-      else defaultArtifactId
-    val coords     = MavenCoordinates(organization.value, artifactId, theVersion, None, art.extension)
-    if (sbtPlugin.value)
-      coords.sbtPlugin().withSbtVersion((pluginCrossBuild / sbtBinaryVersion).value).withScalaVersion(scalaBinaryVersion.value)
+      if (sbtPlugin.value) pluginArtifactId(art.name, sbtBin, scalaBin)
+      else
+        CrossVersion(crossVersion.value, scalaVersion.value, scalaBin)
+          .map(_(art.name))
+          .getOrElse(art.name)
+
+    val coords = MavenCoordinates(organization.value, artifactId, theVersion, None, art.extension)
+    if (sbtPlugin.value) coords.sbtPlugin().withSbtVersion(sbtBin).withScalaVersion(scalaBin)
     else coords
+  }
+
+  private def pluginArtifactId(name: String, sbtBin: String, scalaBin: String): String = {
+    val major: Option[Int] = sbtBin.split('.').headOption.flatMap { s =>
+      scala.util.Try(s.toInt).toOption
+    }
+    major match {
+      case Some(m) if m >= 2 => s"${name}_sbt${m}_${scalaBin}"
+      case _                 => s"${name}_${scalaBin}_${sbtBin}"
+    }
   }
 
   lazy val deployTask = aetherDeploy := Def
@@ -107,11 +138,14 @@ object AetherPlugin extends AutoPlugin {
     .value
 
   def createArtifact(
-      artifacts: Map[Artifact, sbt.File],
+      artifacts: Map[Artifact, PluginCompat.FileRef],
       coords: MavenCoordinates,
       mainArtifact: File
-  ): AetherArtifact = {
-    val prefiltered = artifacts.filterNot { case (a, f) =>
+  )(implicit conv: FileConverter): AetherArtifact = {
+    val artifactsAsFiles: Map[Artifact, File] =
+      artifacts.map { case (a, v) => a -> PluginCompat.toFile(v) }
+
+    val prefiltered = artifactsAsFiles.filterNot { case (a, f) =>
       mainArtifact == f || (a.classifier.isEmpty && a.extension == "jar")
     }
 
@@ -124,18 +158,6 @@ object AetherPlugin extends AutoPlugin {
     AetherArtifact(mainArtifact, realCoords, subArtifacts)
   }
 
-  private def toRepository(
-      repo: RepoRef,
-      credentials: Option[DirectCredentials]
-  ): RemoteRepository = {
-    val builder: Builder = new Builder(repo.name, "default", repo.url.toString)
-    credentials.foreach { c =>
-      println(c)
-      builder.setAuthentication(new AuthenticationBuilder().addUsername(c.userName).addPassword(c.passwd).build())
-    }
-    builder.build()
-  }
-
   def deployIt(
       repo: Option[Resolver],
       localRepo: File,
@@ -143,8 +165,8 @@ object AetherPlugin extends AutoPlugin {
       cred: Seq[Credentials],
       customHeaders: Map[String, String]
   )(implicit
-      stream: TaskStreams
-  ) {
+      stream: sbt.std.TaskStreams[_]
+  ): Unit = {
     object IsPatternMavenRepo {
       def unapply(resolver: Resolver): Option[(sbt.PatternsBasedRepository, String)] = {
         resolver match {
@@ -171,15 +193,20 @@ object AetherPlugin extends AutoPlugin {
 
     val maybeCred = Try {
       val href = repository.url
-      val c    = Credentials.forHost(cred, href.getHost)
+      val c    = PluginCompat.credentialForHost(cred, href.getHost)
       if (c.isEmpty && href.getHost != null) {
         stream.log.warn("No credentials supplied for %s".format(href.getHost))
       }
       c
     }.toOption.flatten
 
+    val builder = new Builder(repository.name, "default", repository.url.toString)
+    maybeCred.foreach { c =>
+      builder.setAuthentication(new AuthenticationBuilder().addUsername(c.userName).addPassword(c.passwd).build())
+    }
+
     val request = new DeployRequest()
-    request.setRepository(toRepository(repository, maybeCred))
+    request.setRepository(builder.build())
     val parent  = artifact.toArtifact
     request.addArtifact(parent)
     artifact.subartifacts.foreach(s => request.addArtifact(s.toArtifact(parent)))
@@ -192,7 +219,7 @@ object AetherPlugin extends AutoPlugin {
     }
   }
 
-  def installIt(artifact: AetherArtifact, localRepo: File)(implicit streams: TaskStreams) {
+  def installIt(artifact: AetherArtifact, localRepo: File)(implicit streams: sbt.std.TaskStreams[_]): Unit = {
 
     val request = new InstallRequest()
     val parent  = artifact.toArtifact

--- a/aether-deploy/src/main/scala/aether/Plugin.scala
+++ b/aether-deploy/src/main/scala/aether/Plugin.scala
@@ -145,7 +145,7 @@ object AetherPlugin extends AutoPlugin {
     val artifactsAsFiles: Map[Artifact, File] =
       artifacts.map { case (a, v) => a -> PluginCompat.toFile(v) }
 
-    val prefiltered = artifactsAsFiles.filterNot { case (a, f) =>
+    val prefiltered                           = artifactsAsFiles.filterNot { case (a, f) =>
       mainArtifact == f || (a.classifier.isEmpty && a.extension == "jar")
     }
 

--- a/aether-deploy/src/main/scala/aether/Plugin.scala
+++ b/aether-deploy/src/main/scala/aether/Plugin.scala
@@ -76,7 +76,7 @@ object AetherPlugin extends AutoPlugin {
       PluginCompat.toFile((Compile / Keys.`package`).value)
     },
     sbtPluginPublishLegacyMavenStyle := false,
-    aetherDeploy / version := (ThisBuild / version).value,
+    aetherDeploy / version := version.value,
     aetherDeploy / logLevel := Level.Debug,
     aetherCustomHttpHeaders := Map.empty[String, String]
   )

--- a/aether-deploy/src/main/scala/aether/Plugin.scala
+++ b/aether-deploy/src/main/scala/aether/Plugin.scala
@@ -26,8 +26,7 @@ object AetherKeys {
   val aetherLocalRepo         = settingKey[File]("Local maven repository.")
   val aetherCustomHttpHeaders = settingKey[Map[String, String]]("Add these headers to the http request")
 
-  /** Attach an additional sub-artefact (sourced from a task that produces a packaged file)
-    * to the main `aetherArtifact`.
+  /** Attach an additional sub-artefact (sourced from a task that produces a packaged file) to the main `aetherArtifact`.
     */
   def attachSubArtifact(
       packageTask: sbt.TaskKey[sbtcompat.PluginCompat.FileRef],
@@ -67,18 +66,18 @@ object AetherPlugin extends AutoPlugin {
   }
 
   lazy val aetherBaseSettings: Seq[Setting[?]] = Seq(
-    aetherLocalRepo := Path.userHome / ".m2" / "repository",
+    aetherLocalRepo                  := Path.userHome / ".m2" / "repository",
     defaultCoordinates,
     deployTask,
     installTask,
-    aetherPackageMain := Def.uncached {
+    aetherPackageMain                := Def.uncached {
       implicit val conv: FileConverter = fileConverter.value
       PluginCompat.toFile((Compile / Keys.`package`).value)
     },
     sbtPluginPublishLegacyMavenStyle := false,
-    aetherDeploy / version := version.value,
-    aetherDeploy / logLevel := Level.Debug,
-    aetherCustomHttpHeaders := Map.empty[String, String]
+    aetherDeploy / version           := version.value,
+    aetherDeploy / logLevel          := Level.Debug,
+    aetherCustomHttpHeaders          := Map.empty[String, String]
   )
 
   def defaultCoordinates = aetherCoordinates := {
@@ -145,7 +144,7 @@ object AetherPlugin extends AutoPlugin {
     val artifactsAsFiles: Map[Artifact, File] =
       artifacts.map { case (a, v) => a -> PluginCompat.toFile(v) }
 
-    val prefiltered                           = artifactsAsFiles.filterNot { case (a, f) =>
+    val prefiltered = artifactsAsFiles.filterNot { case (a, f) =>
       mainArtifact == f || (a.classifier.isEmpty && a.extension == "jar")
     }
 

--- a/aether-deploy/src/main/scala/aether/Plugin.scala
+++ b/aether-deploy/src/main/scala/aether/Plugin.scala
@@ -57,16 +57,16 @@ object AetherPlugin extends AutoPlugin {
   )
 
   object autoImport {
-    def overridePublishSettings: Seq[Setting[_]]      = Seq(publish := aetherDeploy.value)
-    def overridePublishLocalSettings: Seq[Setting[_]] =
+    def overridePublishSettings: Seq[Setting[?]]      = Seq(publish := aetherDeploy.value)
+    def overridePublishLocalSettings: Seq[Setting[?]] =
       Seq(publishLocal := {
         publishLocal.value
         aetherInstall.value
       })
-    def overridePublishBothSettings: Seq[Setting[_]]  = overridePublishSettings ++ overridePublishLocalSettings
+    def overridePublishBothSettings: Seq[Setting[?]]  = overridePublishSettings ++ overridePublishLocalSettings
   }
 
-  lazy val aetherBaseSettings: Seq[Setting[_]] = Seq(
+  lazy val aetherBaseSettings: Seq[Setting[?]] = Seq(
     aetherLocalRepo := Path.userHome / ".m2" / "repository",
     defaultCoordinates,
     deployTask,
@@ -164,9 +164,7 @@ object AetherPlugin extends AutoPlugin {
       artifact: AetherArtifact,
       cred: Seq[Credentials],
       customHeaders: Map[String, String]
-  )(implicit
-      stream: sbt.std.TaskStreams[_]
-  ): Unit = {
+  )(stream: sbt.std.TaskStreams[?]): Unit = {
     object IsPatternMavenRepo {
       def unapply(resolver: Resolver): Option[(sbt.PatternsBasedRepository, String)] = {
         resolver match {
@@ -219,7 +217,7 @@ object AetherPlugin extends AutoPlugin {
     }
   }
 
-  def installIt(artifact: AetherArtifact, localRepo: File)(implicit streams: sbt.std.TaskStreams[_]): Unit = {
+  def installIt(artifact: AetherArtifact, localRepo: File)(streams: sbt.std.TaskStreams[?]): Unit = {
 
     val request = new InstallRequest()
     val parent  = artifact.toArtifact

--- a/aether-deploy/src/main/scala/aether/internal/Booter.scala
+++ b/aether-deploy/src/main/scala/aether/internal/Booter.scala
@@ -9,7 +9,7 @@ import org.eclipse.aether.{ConfigurationProperties, DefaultRepositorySystemSessi
 import sbt.std.TaskStreams
 
 import java.io.File
-import scala.collection.JavaConverters.mapAsJavaMap
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 object Booter {
@@ -20,7 +20,7 @@ object Booter {
 
   private def init(
       localRepoDir: File,
-      streams: TaskStreams[_],
+      streams: TaskStreams[?],
       coordinates: MavenCoordinates
   ): (RepositorySystem, DefaultRepositorySystemSession) = {
     val system = newRepositorySystem()
@@ -29,7 +29,7 @@ object Booter {
 
   def deploy(
       localRepoDir: File,
-      streams: TaskStreams[_],
+      streams: TaskStreams[?],
       coordinates: MavenCoordinates,
       customHeaders: Map[String, String],
       request: DeployRequest
@@ -37,14 +37,14 @@ object Booter {
     val (system, session) = init(localRepoDir, streams, coordinates)
     if (customHeaders.nonEmpty) {
       session
-        .setConfigProperty(ConfigurationProperties.HTTP_HEADERS + "." + request.getRepository.getId, mapAsJavaMap(customHeaders))
+        .setConfigProperty(ConfigurationProperties.HTTP_HEADERS + "." + request.getRepository.getId, customHeaders.asJava)
     }
     system.deploy(session, request)
   }
 
   def install(
       localRepoDir: File,
-      streams: TaskStreams[_],
+      streams: TaskStreams[?],
       coordinates: MavenCoordinates,
       request: InstallRequest
   ): Try[Unit] = Try {
@@ -52,10 +52,10 @@ object Booter {
     system.install(session, request)
   }
 
-  private def newSession(implicit
+  private def newSession(
       system: RepositorySystem,
       localRepoDir: File,
-      streams: TaskStreams[_],
+      streams: TaskStreams[?],
       coordinates: MavenCoordinates
   ): DefaultRepositorySystemSession = {
     val session   = new DefaultRepositorySystemSession()
@@ -63,7 +63,7 @@ object Booter {
     session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepo))
     session.setTransferListener(new ConsoleTransferListener(streams.log))
     session.setRepositoryListener(new ConsoleRepositoryListener(streams.log))
-    session.setUserProperties(mapAsJavaMap(coordinates.props))
+    session.setUserProperties(coordinates.props.asJava)
     session.setProxySelector(SystemPropertyProxySelector.apply())
     session
   }

--- a/aether-deploy/src/main/scala/aether/internal/ConsoleRepositoryListener.scala
+++ b/aether-deploy/src/main/scala/aether/internal/ConsoleRepositoryListener.scala
@@ -5,82 +5,82 @@ import org.eclipse.aether.{AbstractRepositoryListener, RepositoryEvent}
 import sbt.Logger
 
 class ConsoleRepositoryListener(logger: Logger) extends AbstractRepositoryListener {
-  override def artifactDeployed(event: RepositoryEvent) {
+  override def artifactDeployed(event: RepositoryEvent): Unit = {
     logger.info("Deployed " + event.getArtifact + " to " + event.getRepository)
   }
 
-  override def artifactDeploying(event: RepositoryEvent) {
+  override def artifactDeploying(event: RepositoryEvent): Unit = {
     logger.info("Deploying " + event.getArtifact + " to " + event.getRepository)
   }
 
-  override def artifactDescriptorInvalid(event: RepositoryEvent) {
+  override def artifactDescriptorInvalid(event: RepositoryEvent): Unit = {
     logger.info(
       "Invalid artifact descriptor for " + event.getArtifact + ": "
         + event.getException.getMessage
     )
   }
 
-  override def artifactDescriptorMissing(event: RepositoryEvent) {
+  override def artifactDescriptorMissing(event: RepositoryEvent): Unit = {
     logger.info("Missing artifact descriptor for " + event.getArtifact)
   }
 
-  override def artifactDownloaded(event: RepositoryEvent) {
+  override def artifactDownloaded(event: RepositoryEvent): Unit = {
     logger.info("Downloaded artifact " + event.getArtifact + " from " + event.getRepository)
   }
 
-  override def artifactDownloading(event: RepositoryEvent) {
+  override def artifactDownloading(event: RepositoryEvent): Unit = {
     logger.info("Downloading artifact " + event.getArtifact + " from " + event.getRepository)
   }
 
-  override def artifactInstalled(event: RepositoryEvent) {
+  override def artifactInstalled(event: RepositoryEvent): Unit = {
     logger.info("Installed " + event.getArtifact + " to " + event.getFile)
   }
 
-  override def artifactInstalling(event: RepositoryEvent) {
+  override def artifactInstalling(event: RepositoryEvent): Unit = {
     logger.info("Installing " + event.getArtifact + " to " + event.getFile)
   }
 
-  override def artifactResolved(event: RepositoryEvent) {
+  override def artifactResolved(event: RepositoryEvent): Unit = {
     logger.info("Resolved artifact " + event.getArtifact + " from " + event.getRepository)
   }
 
-  override def artifactResolving(event: RepositoryEvent) {
+  override def artifactResolving(event: RepositoryEvent): Unit = {
     logger.info("Resolving artifact " + event.getArtifact)
   }
 
-  override def metadataDeployed(event: RepositoryEvent) {
+  override def metadataDeployed(event: RepositoryEvent): Unit = {
     logger.info("Deployed " + event.getMetadata + " to " + event.getRepository)
   }
 
-  override def metadataDeploying(event: RepositoryEvent) {
+  override def metadataDeploying(event: RepositoryEvent): Unit = {
     logger.info("Deploying " + event.getMetadata + " to " + event.getRepository)
   }
 
-  override def metadataDownloaded(event: RepositoryEvent) {
+  override def metadataDownloaded(event: RepositoryEvent): Unit = {
     logger.info("Downloaded metadata " + event.getMetadata + " from " + event.getRepository)
   }
 
-  override def metadataDownloading(event: RepositoryEvent) {
+  override def metadataDownloading(event: RepositoryEvent): Unit = {
     logger.info("Downloading metadata " + event.getMetadata + " from " + event.getRepository)
   }
 
-  override def metadataInstalled(event: RepositoryEvent) {
+  override def metadataInstalled(event: RepositoryEvent): Unit = {
     logger.info("Installed " + event.getMetadata + " to " + event.getFile)
   }
 
-  override def metadataInstalling(event: RepositoryEvent) {
+  override def metadataInstalling(event: RepositoryEvent): Unit = {
     logger.info("Installing " + event.getMetadata + " to " + event.getFile)
   }
 
-  override def metadataInvalid(event: RepositoryEvent) {
+  override def metadataInvalid(event: RepositoryEvent): Unit = {
     logger.info("Invalid metadata " + event.getMetadata)
   }
 
-  override def metadataResolved(event: RepositoryEvent) {
+  override def metadataResolved(event: RepositoryEvent): Unit = {
     logger.info("Resolved metadata " + event.getMetadata + " from " + event.getRepository)
   }
 
-  override def metadataResolving(event: RepositoryEvent) {
+  override def metadataResolving(event: RepositoryEvent): Unit = {
     logger.info("Resolving metadata " + event.getMetadata + " from " + event.getRepository)
   }
 }

--- a/aether-deploy/src/main/scala/aether/internal/ConsoleTransferListener.scala
+++ b/aether-deploy/src/main/scala/aether/internal/ConsoleTransferListener.scala
@@ -12,13 +12,13 @@ class ConsoleTransferListener(logger: Logger) extends AbstractTransferListener {
 
   private var lastLength: Int = 0
 
-  override def transferInitiated(event: TransferEvent) {
+  override def transferInitiated(event: TransferEvent): Unit = {
     val message = if (event.getRequestType == TransferEvent.RequestType.PUT) "Uploading" else "Downloading"
 
     logger.info(message + ": " + event.getResource.getRepositoryUrl + event.getResource.getResourceName)
   }
 
-  override def transferProgressed(event: TransferEvent) {
+  override def transferProgressed(event: TransferEvent): Unit = {
     val resource = event.getResource
     downloads.put(resource, event.getTransferredBytes)
 
@@ -40,7 +40,7 @@ class ConsoleTransferListener(logger: Logger) extends AbstractTransferListener {
     logger.debug(buffer.toString())
   }
 
-  override def transferSucceeded(event: TransferEvent) {
+  override def transferSucceeded(event: TransferEvent): Unit = {
     transferCompleted(event);
 
     val resource      = event.getResource
@@ -64,13 +64,13 @@ class ConsoleTransferListener(logger: Logger) extends AbstractTransferListener {
     }
   }
 
-  override def transferFailed(event: TransferEvent) {
+  override def transferFailed(event: TransferEvent): Unit = {
     transferCompleted(event)
 
     logger.error(event.getException.getMessage)
   }
 
-  private def transferCompleted(event: TransferEvent) {
+  private def transferCompleted(event: TransferEvent): Unit = {
     downloads.remove(event.getResource)
 
     val buffer = new StringBuilder(64)
@@ -79,11 +79,11 @@ class ConsoleTransferListener(logger: Logger) extends AbstractTransferListener {
     logger.info(buffer.toString())
   }
 
-  override def transferCorrupted(event: TransferEvent) {
+  override def transferCorrupted(event: TransferEvent): Unit = {
     logger.error(event.getException.getMessage)
   }
 
-  private def pad(buffer: StringBuilder, spaces: Int) {
+  private def pad(buffer: StringBuilder, spaces: Int): Unit = {
     var thespaces = spaces
     val block     = "                                        "
     while (thespaces > 0) {

--- a/aether-deploy/src/main/scala/aether/internal/ConsoleTransferListener.scala
+++ b/aether-deploy/src/main/scala/aether/internal/ConsoleTransferListener.scala
@@ -24,7 +24,7 @@ class ConsoleTransferListener(logger: Logger) extends AbstractTransferListener {
 
     val buffer = new StringBuilder(64)
 
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     for (entry <- downloads.entrySet().asScala) {
       val total    = entry.getKey.getContentLength
       val complete = entry.getValue
@@ -47,7 +47,7 @@ class ConsoleTransferListener(logger: Logger) extends AbstractTransferListener {
     val contentLength = event.getTransferredBytes
     if (contentLength >= 0) {
       val t   = if (event.getRequestType == TransferEvent.RequestType.PUT) "Uploaded" else "Downloaded"
-      val len = if (contentLength >= 1024) toKB(contentLength) + " KB" else contentLength + " B"
+      val len = if (contentLength >= 1024) s"${toKB(contentLength)} KB" else s"$contentLength B"
 
       var throughput = ""
       val duration   = System.currentTimeMillis() - resource.getTransferStartTime
@@ -97,13 +97,13 @@ class ConsoleTransferListener(logger: Logger) extends AbstractTransferListener {
 
   private def getStatus(complete: Long, total: Long): String = {
     if (total >= 1024) {
-      toKB(complete) + "/" + toKB(total) + " KB "
+      s"${toKB(complete)}/${toKB(total)} KB "
     } else if (total >= 0) {
-      complete + "/" + total + " B "
+      s"$complete/$total B "
     } else if (complete >= 1024) {
-      toKB(complete) + " KB "
+      s"${toKB(complete)} KB "
     } else {
-      complete + " B "
+      s"$complete B "
     }
   }
 

--- a/aether-deploy/src/main/scala/aether/internal/SystemPropertyProxySelector.scala
+++ b/aether-deploy/src/main/scala/aether/internal/SystemPropertyProxySelector.scala
@@ -35,9 +35,8 @@ private[aether] object SystemPropertyProxySelector {
 
   def apply(): ProxySelector = selector
 
-  /** java -Dhttp.proxyHost=myproxy -Dhttp.proxyPort=8080 \
-    *      -Dhttp.proxyUser=username -Dhttp.proxyPassword=mypassword \
-    *      -Dhttp.nonProxyHosts=
+  /** java -Dhttp.proxyHost=myproxy -Dhttp.proxyPort=8080 \ -Dhttp.proxyUser=username -Dhttp.proxyPassword=mypassword \
+    * -Dhttp.nonProxyHosts=
     * @return
     */
   private def loadProxies(): Option[AProxy] = {

--- a/aether-deploy/src/sbt-test/deploy/deploy-projectmatrix/build.sbt
+++ b/aether-deploy/src/sbt-test/deploy/deploy-projectmatrix/build.sbt
@@ -1,0 +1,12 @@
+version  := "0.1.0"
+organization := "deploy-file"
+
+scalaVersion := "3.8.3"
+
+val projectMatrixScripted =
+  projectMatrix.in(file("."))
+    .jvmPlatform(scalaVersions = Seq("3.8.3"))
+
+
+publishTo  := Some("foo" at (file(".") / "target" / "repo").toURI.toURL.toString)
+

--- a/aether-deploy/src/sbt-test/deploy/deploy-projectmatrix/project/build.properties
+++ b/aether-deploy/src/sbt-test/deploy/deploy-projectmatrix/project/build.properties
@@ -1,0 +1,2 @@
+# projectMatrix is built into sbt 2.x; not available in sbt 1.x
+sbt.version = 2.0.0-RC12

--- a/aether-deploy/src/sbt-test/deploy/deploy-projectmatrix/project/plugins.sbt
+++ b/aether-deploy/src/sbt-test/deploy/deploy-projectmatrix/project/plugins.sbt
@@ -1,0 +1,7 @@
+val pluginVersion = scala.util.Properties.propOrNone("plugin.version").getOrElse(
+throw new RuntimeException("""
+  |The system property 'plugin.version' is not defined.
+  |Specify this property using the scriptedLaunchOpts -D.
+""".stripMargin))
+
+addSbtPlugin("no.arktekk.sbt" % "aether-deploy" % pluginVersion)

--- a/aether-deploy/src/sbt-test/deploy/deploy-projectmatrix/test
+++ b/aether-deploy/src/sbt-test/deploy/deploy-projectmatrix/test
@@ -1,0 +1,7 @@
+# Deploy a projectMatrix-derived project to a file:// repo
+> aetherDeploy
+$ exists target/repo/deploy-file
+$ exists target/repo/deploy-file/projectmatrixscripted_3/maven-metadata.xml
+$ exists target/repo/deploy-file/projectmatrixscripted_3/0.1.0/
+$ exists target/repo/deploy-file/projectmatrixscripted_3/0.1.0/projectmatrixscripted_3-0.1.0.jar
+$ exists target/repo/deploy-file/projectmatrixscripted_3/0.1.0/projectmatrixscripted_3-0.1.0.pom

--- a/aether-deploy/src/sbt-test/deploy/deploy-sbt-sonatype/project/build.properties
+++ b/aether-deploy/src/sbt-test/deploy/deploy-sbt-sonatype/project/build.properties
@@ -1,0 +1,2 @@
+# Sonatype publishing now supported directly in sbt 2.x
+sbt.version = 1.11.0

--- a/aether-deploy/src/sbt-test/deploy/native-packaging/build.sbt
+++ b/aether-deploy/src/sbt-test/deploy/native-packaging/build.sbt
@@ -1,20 +1,21 @@
 import aether.AetherKeys._
 
-ThisBuild / version  := "0.1"
+ThisBuild / version := "0.1"
 
 name := "packaged-app"
 
 organization := "deploy"
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.21"
 
 enablePlugins(JavaAppPackaging)
 
-publishTo  := Some("foo" at (file(".") / "target" / "repo").toURI.toURL.toString)
+publishTo := Some("foo" at (file(".") / "target" / "repo").toURI.toURL.toString)
 
 overridePublishSettings
 
-aetherArtifact := {
-    val artifact = aetherArtifact.value
-    artifact.attach((Universal / packageBin).value, "dist", "zip")
-}
+// Setting-level helper mirroring sbt-native-packager's `SettingsHelper.addPackage`:
+// the task's File/HashedVirtualFileRef return type and the sbt 2.x task-value cache
+// are handled internally, so the consuming build file needs no `fileConverter.value`,
+// no `implicit val`, and no `Def.uncached` wrapping.
+attachSubArtifact(Universal / packageBin, "dist", "zip")

--- a/aether-deploy/src/sbt-test/deploy/native-packaging/project/plugins.sbt
+++ b/aether-deploy/src/sbt-test/deploy/native-packaging/project/plugins.sbt
@@ -1,9 +1,11 @@
-val pluginVersion = scala.util.Properties.propOrNone("plugin.version").getOrElse(
-  throw new RuntimeException("""
-                               |The system property 'plugin.version' is not defined.
-                               |Specify this property using the scriptedLaunchOpts -D.
-                             """.stripMargin))
+val pluginVersion = scala.util.Properties
+  .propOrNone("plugin.version")
+  .getOrElse(
+    throw new RuntimeException("""
+                                 |The system property 'plugin.version' is not defined.
+                                 |Specify this property using the scriptedLaunchOpts -D.
+                               """.stripMargin))
 
 addSbtPlugin("no.arktekk.sbt" % "aether-deploy" % pluginVersion)
 
-addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.1")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.7")

--- a/aether-deploy/src/sbt-test/deploy/sbt-plugin/build.sbt
+++ b/aether-deploy/src/sbt-test/deploy/sbt-plugin/build.sbt
@@ -9,3 +9,39 @@ enablePlugins(SbtPlugin)
 publishTo := Some("foo" at (file(".") / "target" / "repo").toURI.toURL.toString)
 
 overridePublishSettings
+
+// validates the published sbt-plugin artefact exists under the coordinate directory appropriate
+// for the current sbt binary version.
+//  - sbt 1.x : <name>_<scalaBinaryVersion>_<sbtBinaryVersion>  e.g. sbt-plugin_2.12_1.0
+//  - sbt 2.x : <name>_sbt<sbtBinaryVersion>_<scalaBinaryVersion>  e.g. sbt-plugin_sbt2_3
+TaskKey[Unit]("checkPublished") := {
+  val sbtBin = (pluginCrossBuild / sbtBinaryVersion).value
+  val scalaBin = scalaBinaryVersion.value
+  val majorOpt = sbtBin.split('.').headOption.flatMap(s => scala.util.Try(s.toInt).toOption)
+  val suffix = majorOpt match {
+    case Some(m) if m >= 2 => s"_sbt${m}_$scalaBin"
+    case _                 => s"_${scalaBin}_$sbtBin"
+  }
+  val repo = (baseDirectory.value / "target" / "repo" / "sbt-plugin" / s"sbt-plugin$suffix")
+  val ver = repo / "0.1"
+  val expected = List(
+    repo / "maven-metadata.xml",
+    ver,
+    ver / s"sbt-plugin$suffix-0.1.jar",
+    ver / s"sbt-plugin$suffix-0.1.pom",
+    ver / s"sbt-plugin$suffix-0.1-sources.jar",
+    ver / s"sbt-plugin$suffix-0.1-javadoc.jar"
+  )
+  expected.foreach { f =>
+    if (!f.exists()) sys.error(s"Expected published artefact not found: ${f.getAbsolutePath}")
+  }
+  val forbidden = List(
+    ver / "sbt-plugin-0.1.jar",
+    ver / "sbt-plugin-0.1.pom",
+    ver / "sbt-plugin-0.1-sources.jar",
+    ver / "sbt-plugin-0.1-javadoc.jar"
+  )
+  forbidden.foreach { f =>
+    if (f.exists()) sys.error(s"Unexpected legacy-style artefact present: ${f.getAbsolutePath}")
+  }
+}

--- a/aether-deploy/src/sbt-test/deploy/sbt-plugin/test
+++ b/aether-deploy/src/sbt-test/deploy/sbt-plugin/test
@@ -1,13 +1,4 @@
-# Deploy to file url
+# Publish the sbt plugin and validate the artefact layout.
 > publish
 $ exists target/repo/sbt-plugin
-$ exists target/repo/sbt-plugin/sbt-plugin_2.12_1.0/maven-metadata.xml
-$ exists target/repo/sbt-plugin/sbt-plugin_2.12_1.0/0.1/
-$ exists target/repo/sbt-plugin/sbt-plugin_2.12_1.0/0.1/sbt-plugin_2.12_1.0-0.1.jar
-$ exists target/repo/sbt-plugin/sbt-plugin_2.12_1.0/0.1/sbt-plugin_2.12_1.0-0.1.pom
-$ exists target/repo/sbt-plugin/sbt-plugin_2.12_1.0/0.1/sbt-plugin_2.12_1.0-0.1-sources.jar
-$ exists target/repo/sbt-plugin/sbt-plugin_2.12_1.0/0.1/sbt-plugin_2.12_1.0-0.1-javadoc.jar
-$ absent target/repo/sbt-plugin/sbt-plugin_2.12_1.0/0.1/sbt-plugin-0.1.jar
-$ absent target/repo/sbt-plugin/sbt-plugin_2.12_1.0/0.1/sbt-plugin-0.1.pom
-$ absent target/repo/sbt-plugin/sbt-plugin_2.12_1.0/0.1/sbt-plugin-0.1-sources.jar
-$ absent target/repo/sbt-plugin/sbt-plugin_2.12_1.0/0.1/sbt-plugin-0.1-javadoc.jar
+> checkPublished

--- a/aether-deploy/src/sbt-test/deploy/webapp/project/build.properties
+++ b/aether-deploy/src/sbt-test/deploy/webapp/project/build.properties
@@ -1,0 +1,2 @@
+# xsbt-web-plugin not yet released for sbt 2.x
+sbt.version = 1.11.0

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 organization := "no.arktekk.sbt"
-description := "Deploy in SBT using Sonatype Aether"
+description  := "Deploy in SBT using Sonatype Aether"
 
-val platforms: Seq[(scala: String, sbt:String)] = Seq(
+val platforms: Seq[(scala: String, sbt: String)] = Seq(
   (scala = "2.12.21", sbt = "1.11.0"),
   (scala = "3.8.3", sbt = "2.0.0-RC12")
 )
@@ -25,10 +25,10 @@ lazy val aetherDeploy =
           // See arktekk/sbt-aether-deploy#43.
           ("org.apache.maven.resolver" % "maven-resolver-supplier" % "1.9.23")
             .exclude("org.codehaus.plexus", "plexus-utils"),
-          "org.codehaus.plexus" % "plexus-utils" % "3.6.0",
-          "org.scala-lang.modules" %% "scala-collection-compat" % "2.14.0"
+          "org.codehaus.plexus"        % "plexus-utils"            % "3.6.0",
+          "org.scala-lang.modules"    %% "scala-collection-compat" % "2.14.0"
         )
-      },
+      }
     )
 
 lazy val aetherDeploySigned =
@@ -45,7 +45,8 @@ lazy val aetherDeploySigned =
     )
 
 lazy val aetherDeployRoot =
-  projectMatrix.in(file("."))
+  projectMatrix
+    .in(file("."))
     .jvmPlatform(scalaVersions = platforms.map(_.scala))
     .aggregate(aetherDeploy)
     .aggregate(aetherDeploySigned)
@@ -55,10 +56,10 @@ def commonSettings =
   val scala3 = Def.setting(scalaBinaryVersion.value == "3")
   Seq(
     pluginCrossBuild / sbtVersion := platforms.find(_.scala == scalaVersion.value).get.sbt,
-    javacOptions := {
+    javacOptions                  := {
       if (scala3.value) Seq("--release", "17") else Seq("--release", "8")
     },
-    scalacOptions := {
+    scalacOptions                 := {
       val shared = Seq("-deprecation", "-unchecked")
       if (scala3.value) shared :+ "-release:17" else shared :+ "-release:8"
     }
@@ -69,5 +70,5 @@ def scriptedSettings = Seq(
     scriptedLaunchOpts.value ++
       Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
   },
-  scriptedBufferLog := false,
+  scriptedBufferLog  := false
 )

--- a/build.sbt
+++ b/build.sbt
@@ -27,10 +27,6 @@ lazy val aetherDeploy = (project in file("aether-deploy"))
   .settings(commonSettings)
   .settings(
     name := "aether-deploy",
-    // sbt2-compat provides `sbtcompat.PluginCompat` - a cross-published shim exposing the
-    // sbt 2.x API (FileRef / HashedVirtualFileRef, FileConverter, Def.uncached,
-    // Credentials helpers, etc.) on top of sbt 1.x primitives. Following the pattern
-    // used by sbt-native-packager, this replaces any hand-rolled per-version compat.
     addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0"),
     libraryDependencies ++= {
       Seq(
@@ -39,7 +35,8 @@ lazy val aetherDeploy = (project in file("aether-deploy"))
         // See arktekk/sbt-aether-deploy#43.
         ("org.apache.maven.resolver" % "maven-resolver-supplier" % "1.9.23")
           .exclude("org.codehaus.plexus", "plexus-utils"),
-        "org.codehaus.plexus"        % "plexus-utils"            % "3.6.0"
+        "org.codehaus.plexus"        % "plexus-utils"            % "3.6.0",
+        "org.scala-lang.modules"    %% "scala-collection-compat" % "2.14.0"
       )
     },
     scriptedDependencies := {

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,9 @@ ThisBuild / organization := "no.arktekk.sbt"
 
 ThisBuild / description := "Deploy in SBT using Sonatype Aether"
 
-ThisBuild / javacOptions := Seq("--release", "8")
-ThisBuild / scalacOptions := Seq("-deprecation", "-unchecked", "-release", "8")
+ThisBuild / scalaVersion := (ThisBuild / crossScalaVersions).value.head
+ThisBuild / crossScalaVersions := Seq("2.12.21", "3.8.3")
+val isScala3 = Def.setting(scalaBinaryVersion.value == "3")
 
 ThisBuild / scriptedLaunchOpts := {
   scriptedLaunchOpts.value ++
@@ -12,24 +13,56 @@ ThisBuild / scriptedLaunchOpts := {
 
 ThisBuild / scriptedBufferLog := false
 
+val commonSettings = Seq(
+  pluginCrossBuild / sbtVersion :=  { if (isScala3.value) "2.0.0-RC12" else "1.11.0" },
+  javacOptions := { if (isScala3.value) Seq("--release", "17") else Seq("--release", "8") },
+  scalacOptions := {
+    val shared = Seq("-deprecation", "-unchecked")
+    if (isScala3.value) shared :+ "-release:17" else shared :+ "-release:8"
+  }
+)
+
 lazy val aetherDeploy = (project in file("aether-deploy"))
   .enablePlugins(SbtPlugin)
+  .settings(commonSettings)
   .settings(
     name := "aether-deploy",
+    // sbt2-compat provides `sbtcompat.PluginCompat` - a cross-published shim exposing the
+    // sbt 2.x API (FileRef / HashedVirtualFileRef, FileConverter, Def.uncached,
+    // Credentials helpers, etc.) on top of sbt 1.x primitives. Following the pattern
+    // used by sbt-native-packager, this replaces any hand-rolled per-version compat.
+    addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0"),
     libraryDependencies ++= {
-      val mavenResolverVersion = "1.9.23"
       Seq(
-        "org.apache.maven.resolver" % "maven-resolver-supplier" % mavenResolverVersion
+        // Exclude plexus-utils transitively so resolution on cannot silently upgrade to plexus-utils 4.x
+        // which dropped the `org.codehaus.plexus.util.xml.pull` package we depend on at runtime.
+        // See arktekk/sbt-aether-deploy#43.
+        ("org.apache.maven.resolver" % "maven-resolver-supplier" % "1.9.23")
+          .exclude("org.codehaus.plexus", "plexus-utils"),
+        "org.codehaus.plexus"        % "plexus-utils"            % "3.6.0"
       )
+    },
+    scriptedDependencies := {
+      scriptedDependencies.value: Unit
+      val scala3             = isScala3.value
+      val sbt2Skipped = Seq(
+        "deploy/deploy-sbt-sonatype", // Sonatype publishing natively supported in sbt 2.x
+        "deploy/webapp"               // xsbt-web-plugin not yet released for sbt 2.x
+      )
+      sbt2Skipped.foreach { rel =>
+        val marker = sbtTestDirectory.value / rel / "disabled"
+        if (scala3) IO.touch(marker) else IO.delete(marker)
+      }
     }
   )
 
 lazy val aetherDeploySigned = (project in file("aether-deploy-signed"))
   .enablePlugins(SbtPlugin)
   .dependsOn(aetherDeploy)
+  .settings(commonSettings)
   .settings(
     name := "aether-deploy-signed",
-    addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
+    addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
   )
 
 lazy val aetherDeployRoot = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -1,67 +1,73 @@
-ThisBuild / organization := "no.arktekk.sbt"
+organization := "no.arktekk.sbt"
+description := "Deploy in SBT using Sonatype Aether"
 
-ThisBuild / description := "Deploy in SBT using Sonatype Aether"
-
-ThisBuild / scalaVersion := (ThisBuild / crossScalaVersions).value.head
-ThisBuild / crossScalaVersions := Seq("2.12.21", "3.8.3")
-val isScala3 = Def.setting(scalaBinaryVersion.value == "3")
-
-ThisBuild / scriptedLaunchOpts := {
-  scriptedLaunchOpts.value ++
-    Seq("-Xmx1024M", "-Dplugin.version=" + (ThisBuild / version).value)
-}
-
-ThisBuild / scriptedBufferLog := false
-
-val commonSettings = Seq(
-  pluginCrossBuild / sbtVersion :=  { if (isScala3.value) "2.0.0-RC12" else "1.11.0" },
-  javacOptions := { if (isScala3.value) Seq("--release", "17") else Seq("--release", "8") },
-  scalacOptions := {
-    val shared = Seq("-deprecation", "-unchecked")
-    if (isScala3.value) shared :+ "-release:17" else shared :+ "-release:8"
-  }
+val platforms: Seq[(scala: String, sbt:String)] = Seq(
+  (scala = "2.12.21", sbt = "1.11.0"),
+  (scala = "3.8.3", sbt = "2.0.0-RC12")
 )
 
-lazy val aetherDeploy = (project in file("aether-deploy"))
-  .enablePlugins(SbtPlugin)
-  .settings(commonSettings)
-  .settings(
-    name := "aether-deploy",
-    addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0"),
-    libraryDependencies ++= {
-      Seq(
-        // Exclude plexus-utils transitively so resolution on cannot silently upgrade to plexus-utils 4.x
-        // which dropped the `org.codehaus.plexus.util.xml.pull` package we depend on at runtime.
-        // See arktekk/sbt-aether-deploy#43.
-        ("org.apache.maven.resolver" % "maven-resolver-supplier" % "1.9.23")
-          .exclude("org.codehaus.plexus", "plexus-utils"),
-        "org.codehaus.plexus"        % "plexus-utils"            % "3.6.0",
-        "org.scala-lang.modules"    %% "scala-collection-compat" % "2.14.0"
-      )
+scalaVersion := platforms.head.scala
+
+lazy val aetherDeploy =
+  projectMatrix
+    .in(file("aether-deploy"))
+    .jvmPlatform(scalaVersions = platforms.map(_.scala))
+    .enablePlugins(SbtPlugin)
+    .settings(commonSettings)
+    .settings(scriptedSettings)
+    .settings(
+      name := "aether-deploy",
+      addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0"),
+      libraryDependencies ++= {
+        Seq(
+          // Exclude plexus-utils transitively so resolution on cannot silently upgrade to plexus-utils 4.x
+          // which dropped the `org.codehaus.plexus.util.xml.pull` package we depend on at runtime.
+          // See arktekk/sbt-aether-deploy#43.
+          ("org.apache.maven.resolver" % "maven-resolver-supplier" % "1.9.23")
+            .exclude("org.codehaus.plexus", "plexus-utils"),
+          "org.codehaus.plexus" % "plexus-utils" % "3.6.0",
+          "org.scala-lang.modules" %% "scala-collection-compat" % "2.14.0"
+        )
+      },
+    )
+
+lazy val aetherDeploySigned =
+  projectMatrix
+    .in(file("aether-deploy-signed"))
+    .jvmPlatform(scalaVersions = platforms.map(_.scala))
+    .enablePlugins(SbtPlugin)
+    .dependsOn(aetherDeploy)
+    .settings(commonSettings)
+    .settings(scriptedSettings)
+    .settings(
+      name := "aether-deploy-signed",
+      addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
+    )
+
+lazy val aetherDeployRoot =
+  projectMatrix.in(file("."))
+    .jvmPlatform(scalaVersions = platforms.map(_.scala))
+    .aggregate(aetherDeploy)
+    .aggregate(aetherDeploySigned)
+    .settings(publish / skip := true)
+
+def commonSettings =
+  val scala3 = Def.setting(scalaBinaryVersion.value == "3")
+  Seq(
+    pluginCrossBuild / sbtVersion := platforms.find(_.scala == scalaVersion.value).get.sbt,
+    javacOptions := {
+      if (scala3.value) Seq("--release", "17") else Seq("--release", "8")
     },
-    scriptedDependencies := {
-      scriptedDependencies.value: Unit
-      val scala3             = isScala3.value
-      val sbt2Skipped = Seq(
-        "deploy/deploy-sbt-sonatype", // Sonatype publishing natively supported in sbt 2.x
-        "deploy/webapp"               // xsbt-web-plugin not yet released for sbt 2.x
-      )
-      sbt2Skipped.foreach { rel =>
-        val marker = sbtTestDirectory.value / rel / "disabled"
-        if (scala3) IO.touch(marker) else IO.delete(marker)
-      }
+    scalacOptions := {
+      val shared = Seq("-deprecation", "-unchecked")
+      if (scala3.value) shared :+ "-release:17" else shared :+ "-release:8"
     }
   )
 
-lazy val aetherDeploySigned = (project in file("aether-deploy-signed"))
-  .enablePlugins(SbtPlugin)
-  .dependsOn(aetherDeploy)
-  .settings(commonSettings)
-  .settings(
-    name := "aether-deploy-signed",
-    addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
-  )
-
-lazy val aetherDeployRoot = (project in file("."))
-  .aggregate(aetherDeploy, aetherDeploySigned)
-  .settings(publish / skip := true)
+def scriptedSettings = Seq(
+  scriptedLaunchOpts := {
+    scriptedLaunchOpts.value ++
+      Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+  },
+  scriptedBufferLog := false,
+)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.12.9
+sbt.version = 2.0.0-RC12

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.0
+sbt.version = 1.12.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-pgp"      % "2.3.1")
-addSbtPlugin("org.scalameta"  % "sbt-scalafmt" % "2.5.4")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt" % "2.6.0")

--- a/publish.sbt
+++ b/publish.sbt
@@ -13,15 +13,15 @@ ThisBuild / publishTo := {
 }
 
 // Things we care about primarily because Maven Central demands them
-ThisBuild / homepage := Some(new URL("http://github.com/arktekk/sbt-aether-deploy/"))
+ThisBuild / homepage := Some(url("http://github.com/arktekk/sbt-aether-deploy/"))
 
 ThisBuild / startYear := Some(2012)
 
-ThisBuild / licenses := Seq(("Apache 2", new URL("http://www.apache.org/licenses/LICENSE-2.0.txt")))
+ThisBuild / licenses := Seq(("Apache 2", url("http://www.apache.org/licenses/LICENSE-2.0.txt")))
 
 ThisBuild / scmInfo := Some(
   ScmInfo(
-    new URL("http://github.com/arktekk/sbt-aether-deploy"),
+    url("http://github.com/arktekk/sbt-aether-deploy"),
     "scm:git:git://github.com/arktekk/sbt-aether-deploy.git",
     Some("scm:git:git@github.com:arktekk/sbt-aether-deploy.git")
   )
@@ -31,5 +31,5 @@ ThisBuild / developers += Developer(
   "hamnis",
   "Erlend Hamnaberg",
   "erlend@hamnaberg.net",
-  new URL("http://twitter.com/hamnis")
+  url("http://twitter.com/hamnis")
 )

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,25 +1,25 @@
-ThisBuild / credentials += Credentials(Path.userHome / ".sbt" / "arktekk-credentials")
+credentials += Credentials(Path.userHome / ".sbt" / "arktekk-credentials")
 
-ThisBuild / pomIncludeRepository := { x =>
+pomIncludeRepository := { x =>
   false
 }
 
-ThisBuild / sbtPluginPublishLegacyMavenStyle := false
+sbtPluginPublishLegacyMavenStyle := false
 
-ThisBuild / publishTo := {
+publishTo := {
   val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
   if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
   else localStaging.value
 }
 
 // Things we care about primarily because Maven Central demands them
-ThisBuild / homepage := Some(url("http://github.com/arktekk/sbt-aether-deploy/"))
+homepage := Some(url("http://github.com/arktekk/sbt-aether-deploy/"))
 
-ThisBuild / startYear := Some(2012)
+startYear := Some(2012)
 
-ThisBuild / licenses := Seq(("Apache 2", url("http://www.apache.org/licenses/LICENSE-2.0.txt")))
+licenses := Seq(("Apache 2", url("http://www.apache.org/licenses/LICENSE-2.0.txt")))
 
-ThisBuild / scmInfo := Some(
+scmInfo := Some(
   ScmInfo(
     url("http://github.com/arktekk/sbt-aether-deploy"),
     "scm:git:git://github.com/arktekk/sbt-aether-deploy.git",
@@ -27,7 +27,7 @@ ThisBuild / scmInfo := Some(
   )
 )
 
-ThisBuild / developers += Developer(
+developers += Developer(
   "hamnis",
   "Erlend Hamnaberg",
   "erlend@hamnaberg.net",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.30.0"
+version := "0.30.0"


### PR DESCRIPTION
## Add sbt 2.x Support
- Cross-build the plugin for sbt 1.x (Scala 2.12.21) and sbt 2.x (Scala 3.8.3).
- Migrate this build to sbt 2.x: `projectMatrix` throughout, bare-settings convention.
- `aetherDeploy / version` now reads `version.value` (was hardcoded to `(ThisBuild / version).value`). See *Version source decision* below.
- Added `deploy-projectmatrix` scripted test.
- Update CI build to a matrix build for sbt 1.x and 2.x.

### Version source decision

The current behaviour sources version from `ThisBuild`. New sbt 2.x convention for common project-level settings deprecates use of `ThisBuild` in favour of bare settings. From the [sbt 2 change summary](https://www.scala-sbt.org/2.x/docs/en/changes/sbt-2.0-change-summary.html):

> Bare settings are added to all subprojects, as opposed to just the root subproject, and thus replacing the role that `ThisBuild` has played

For users following this convention, `version` will be incorrect, forcing users to set `ThisBuild / version` with current behaviour. Quick way to reproduce is to run `sbt "show version; show ThisBuild/version"` in this branch (`ThisBuild` was removed from `version.sbt`):

```
[info] aetherDeploy2_12 / version
[info] 	0.30.0
[info] aetherDeploy / version
[info] 	0.30.0
[info] aetherDeployRoot / version
[info] 	0.30.0
[info] version
[info] 	0.30.0
[info] 0.1.0-SNAPSHOT      # ThisBuild/version
```

Every project resolves to `0.30.0` (bare-settings propagation); `ThisBuild / version` is empty and falls back to sbt's global default.

Other than having different behaviour per sbt version targeted, only way I see is to source version from the project `version` instead of `ThisBuild`. This should not break any builds for current users (would only have affected users using the already removed `aetherOldVersionMethod` key **and** using different `version`s at `ThisBuild` and `Project` level). @hamnis will defer to you on this one.
